### PR TITLE
Have lexer report the position at which lexing fails.

### DIFF
--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -1,6 +1,19 @@
 {
 {-# OPTIONS -w  #-}
-module Lexer where
+module Lexer
+  ( alexEOF
+  , alexSetInput
+  , alexGetInput
+  , alexError
+  , alexScan
+  , ignorePendingBytes
+  , alexGetStartCode
+  , runAlex
+  , Alex(..)
+  , Token(..)
+  , AlexReturn(..)
+  , AlexPosn(..)
+  ) where
 
 import Prelude hiding (lex)
 

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -1,13 +1,6 @@
 {
 {-# OPTIONS -w  #-}
-module Lexer
-( Alex(..)
-, AlexPosn(..)
-, Token(..)
-, alexMonadScan
-, runAlex
-, alexGetInput
-) where
+module Lexer where
 
 import Prelude hiding (lex)
 


### PR DESCRIPTION
Dagit: your example was very helpful!

Here's a pull request that is slightly more general: it shows how to get position errors for the lexer as well.  (In your example, you just get a string error from the lexer.  Users might be interested get position info for both the lexer and parser.)
