### PR TITLE
Improved error reporting, including file paths. Removed non-working repl.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,15 +1,14 @@
 module Main(main) where
 
 import Language ( eval )
-import Parser   ( parseExp )
+import Parser ( parseExp )
+import System.Environment ( getArgs )
 
 main :: IO ()
-main = repl
-
-repl :: IO a
-repl = do
-  cs <- getContents
-  case parseExp cs of
-    Left  e -> putStrLn ("error: " ++ e) >> repl
-    Right e -> print (eval [] e) >> repl
-    
+main = do
+  args <- getArgs
+  result <- case args of
+              []  -> fmap (parseExp "<stdin>") getContents
+              [f] -> fmap (parseExp f) (readFile f)
+              _   -> error "expected max. 1 argument"
+  either putStrLn (print . eval []) result


### PR DESCRIPTION
- Previously, the reported positions were not correct and there was no notion of file paths to report. This is fixed via the monadUserState wrapper and keeping positions in the tokens.
- The repl was removed, calling getContents multiple times didn't work anyway.
- Moved things around a bit to keep, so things live where they belong conceptually.

In a nutshell: Now we are even closer to a "real" compiler, emitting commonly understood (emacs!) error messages and carry around positions. We could e.g. annotate the expressions with them, but this has not been done, because it distracts from the actual alex/happy integration.
